### PR TITLE
Fix/position bug

### DIFF
--- a/wm_dynamixel_node/src/WMDynamixel.cpp
+++ b/wm_dynamixel_node/src/WMDynamixel.cpp
@@ -51,6 +51,7 @@ bool WMDynamixel::setVelocity(double newVelocity) {
 }
 
 bool WMDynamixel::setPosition(double newPosition) {
+    newPosition = AngleProxy(0, newPosition);
     //read and calculate new velocity
     int iPosition = (int) ((newPosition / _ratio * _direction + _offset) * 1023 / 6.283185307);
     if (iPosition < 0) {
@@ -85,6 +86,7 @@ bool WMDynamixel::publishPosition(ros::Publisher pub) {
         usleep(DELAY);
         double rawPosition = read2BDynamixel(_ID, ADDR_P1_PRESENT_POSITION_2BYTES, &dxl_error);
         double newPosition = (rawPosition * 6.283185307 / _resolution - _offset) / _direction * _ratio;
+        newPosition = AngleProxy(0, newPosition);
         msg.data.push_back(newPosition);
         if (dxl_error) {
             ROS_WARN("Couldn't read position of dynamixel: ID=%d", _ID);

--- a/wm_dynamixel_node/src/WMDynamixel.h
+++ b/wm_dynamixel_node/src/WMDynamixel.h
@@ -97,15 +97,17 @@ private:
     // Max rotational speed from 0 to 1023 (dynamixel speed units)
     double _maxSpeed;
 
+	double Mod( double A, double N ) {
+		return A-floor(A/N)*N;
+	}
+	double AngleProxy( double A1 = 0, double A2 = 0 ) {  // Give the smallest difference between two angles in rad
+		A1 = A2-A1;
+		A1 = Mod( A1+M_PI, 2*M_PI )-M_PI;
+		return A1;
+	}
+
 };
 
-double Mod( double A, double N ) {
-    return A-floor(A/N)*N;
-}
-double AngleProxy( double A1 = 0, double A2 = 0 ) {  // Give the smallest difference between two angles in rad
-    A1 = A2-A1;
-    A1 = Mod( A1+M_PI, 2*M_PI )-M_PI;
-    return A1;
-}
+
 
 #endif //PROJECT_WMDYNAMIXEL_H

--- a/wm_dynamixel_node/src/WMDynamixel.h
+++ b/wm_dynamixel_node/src/WMDynamixel.h
@@ -99,4 +99,13 @@ private:
 
 };
 
+double Mod( double A, double N ) {
+    return A-floor(A/N)*N;
+}
+double AngleProxy( double A1 = 0, double A2 = 0 ) {  // Give the smallest difference between two angles in rad
+    A1 = A2-A1;
+    A1 = Mod( A1+M_PI, 2*M_PI )-M_PI;
+    return A1;
+}
+
 #endif //PROJECT_WMDYNAMIXEL_H


### PR DESCRIPTION
testé sur sara

corrige un problème avec la lecture de position des joints dynamixels.

### effet secondaire!
Le fix impose la lecture de position entre +pi et -pi. Si le dynamixel sort de ces limites, la sortie sera décalé pour rester entre +pi et -pi